### PR TITLE
Fix re-executing on game move

### DIFF
--- a/CustomModules/292439477.lua
+++ b/CustomModules/292439477.lua
@@ -406,7 +406,7 @@ getfunctions = function()
 end
 getfunctions()
 teleportfunc = game:GetService("Players").LocalPlayer.OnTeleport:Connect(function(State)
-    if State == Enum.TeleportState.Started then
+    if State == Enum.TeleportState.InProgress then
 		if shared.vapekickedfrom then
 			queueteleport('shared.vapekickedfrom = "'..shared.vapekickedfrom..'"')
 		end

--- a/CustomModules/6872265039.lua
+++ b/CustomModules/6872265039.lua
@@ -533,7 +533,7 @@ GuiLibrary["RemoveObject"]("TriggerBotOptionsButton")
 GuiLibrary["RemoveObject"]("ClientKickDisablerOptionsButton")
 
 teleportfunc = lplr.OnTeleport:Connect(function(State)
-    if State == Enum.TeleportState.Started then
+    if State == Enum.TeleportState.InProgress then
 		if shared.vapeoverlay then
 			queueteleport('shared.vapeoverlay = "'..shared.vapeoverlay..'"')
 		end

--- a/CustomModules/6872274481.lua
+++ b/CustomModules/6872274481.lua
@@ -1290,7 +1290,7 @@ task.spawn(function()
 end)
 
 connectionstodisconnect[#connectionstodisconnect + 1] = lplr.OnTeleport:Connect(function(State)
-    if State == Enum.TeleportState.Started then
+    if State == Enum.TeleportState.InProgress then
 		local clientstorestate = bedwars["ClientStoreHandler"] and bedwars["ClientStoreHandler"]:getState() or {Party = {members = 0}}
 		local queuedstring = ''
 		if clientstorestate.Party and clientstorestate.Party.members and #clientstorestate.Party.members > 0 then

--- a/NewMainScript.lua
+++ b/NewMainScript.lua
@@ -1676,7 +1676,7 @@ GUISettings.CreateSlider({
 local GUIbind = GUI.CreateGUIBind()
 
 local teleportfunc = game:GetService("Players").LocalPlayer.OnTeleport:Connect(function(State)
-    if State == Enum.TeleportState.Started and not shared.VapeIndependent then
+    if State == Enum.TeleportState.InProgress and not shared.VapeIndependent then
 		local teleportstr = 'shared.VapeSwitchServers = true if shared.VapeDeveloper then loadstring(readfile("vape/NewMainScript.lua"))() else loadstring(game:HttpGet("https://raw.githubusercontent.com/7GrandDadPGN/VapeV4ForRoblox/main/NewMainScript.lua", true))() end'
 		if shared.VapeDeveloper then
 			teleportstr = 'shared.VapeDeveloper = true '..teleportstr


### PR DESCRIPTION
This fixes the problem of Vape not relaunching when you get teleported to a new game.

# Tested to fix with
- Synapse V2
- Synapse V3
- SW

# Didn't test
- Everything else (lazy)

# The fix:
```lua
Enum.TeleportState.Started
```
isn't called on teleport anymore (it seems)
So an easy fix is to just call "InProgress" or  "RequestedFromServer"
![image](https://user-images.githubusercontent.com/67937010/206887880-443a45f8-f4af-4b1f-9957-63d9a98cd9fd.png)

# Note
"Overlay" still doesn't save info between games
