### PR TITLE
Update Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </h2>
 
 ## Contacts
-[Discord](https://discord.gg/ZqS836yx9k)
+[Discord](https://discord.gg/5gJqhQmrdS)
 <br/>
 [Youtube](https://youtube.com/c/7GrandDadVape)
 
@@ -24,10 +24,10 @@ loadstring(game:HttpGet("https://raw.githubusercontent.com/7GrandDadPGN/VapeV4Fo
 ```
 
 ## Possible Issues
-Half of the time its usually the scripting utility at fault, please make sure the utility meets certain quality standards such as.
+Half of the time its usually the scripting utility at fault, please make sure the utility meets certain quality standards such as:
 1. Supporting file functions & the debug library.
 2. Not implementing lua generated / half baked versions of such functions resulting in unintended behavior.
-3. Maintaing the same behavior across all usages of said functions.
+3. Maintaining the same behavior across all usages of said functions.
 ### User Issues
 If its not the supposed utility at fault, please try some troubleshooting steps.
 1. Deleting the newvape folder (WITH THE GAME CLOSED).

--- a/games/6872274481.lua
+++ b/games/6872274481.lua
@@ -5878,7 +5878,7 @@ run(function()
 				table.clear(Items)
 			end
 		end,
-		Tooltip = 'Automatically puts resources in ender chest'
+		Tooltip = 'Automatically puts resources in personal chest'
 	})
 	UIToggle = AutoBank:CreateToggle({
 		Name = 'UI',


### PR DESCRIPTION
 Hello!

This pull request:
1- updates the Discord server invite link in the README (fixes #3)
2- Fixes a typo in the README
3- Changes "ender chest" to "personal chest" in the description of AutoBank.
(useless change but potentially avoids confusion!)