### PR TITLE
Frontlines fixes

### DIFF
--- a/games/5938036553.lua
+++ b/games/5938036553.lua
@@ -493,6 +493,7 @@ run(function()
 				CircleObject.NumSides = 100
 				CircleObject.Transparency = 1 - CircleTransparency.Value
 				CircleObject.Visible = AimAssist.Enabled
+				CircleObject.Thickness = 1
 			else
 				pcall(function()
 					CircleObject.Visible = false
@@ -711,6 +712,7 @@ run(function()
 				CircleObject.NumSides = 100
 				CircleObject.Transparency = 1 - CircleTransparency.Value
 				CircleObject.Visible = SilentAim.Enabled and Mode.Value == 'Mouse'
+				CircleObject.Thickness = 1
 			else
 				pcall(function()
 					CircleObject.Visible = false

--- a/libraries/drawing.lua
+++ b/libraries/drawing.lua
@@ -74,6 +74,10 @@ local classes = {
 	}
 }
 
+if not commchannel then
+	return '1'
+end
+
 commchannel.Event:Connect(function(...)
 	local actor, key = ...
 	local args = {select(3, ...)}


### PR DESCRIPTION
I was trying out Vape V4 for Frontlines and encountered an error that showed:

<img width="644" height="150" alt="Screenshot 2026-05-21 180535" src="https://github.com/user-attachments/assets/e71170c9-19aa-48a1-8349-002fbe44b839" />

I looked into the `drawing.lua` lib and I was able to fix the issue. Turns out it only needed a simple check and it'll run perfectly normal.

In case if you want to know, I was using the **Madium** executor. So I assume that it also broke with other executors.

<hr>

I also realized that the range circles looked weird, so I fixed those as well. 

<img width="389" height="346" alt="image" src="https://github.com/user-attachments/assets/7364e0f6-7402-4bab-aa38-9d43914457fe" />
